### PR TITLE
add expiration parameter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.1
+version=2.2

--- a/src/main/java/org/moddingx/pastewrapper/PasteApi.java
+++ b/src/main/java/org/moddingx/pastewrapper/PasteApi.java
@@ -1,6 +1,7 @@
 package org.moddingx.pastewrapper;
 
 import com.google.gson.*;
+import org.moddingx.pastewrapper.route.CreateRoute;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,9 +15,9 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 
 public class PasteApi {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(PasteApi.class);
-    
+
     private static final Gson GSON;
 
     static {
@@ -24,7 +25,7 @@ public class PasteApi {
         builder.disableHtmlEscaping();
         GSON = builder.create();
     }
-    
+
     private final String token;
     private final HttpClient client;
 
@@ -34,6 +35,10 @@ public class PasteApi {
     }
 
     public Paste createPaste(@Nullable String title, String content) throws IOException {
+        return this.createPaste(title, content, CreateRoute.DEFAULT_EXPIRATION);
+    }
+
+    public Paste createPaste(@Nullable String title, String content, int expiration) throws IOException {
         try {
             JsonObject json = new JsonObject();
             if (title != null) json.addProperty("description", title);
@@ -43,6 +48,7 @@ public class PasteApi {
             section.addProperty("contents", content);
             sections.add(section);
             json.add("sections", sections);
+            json.addProperty("expiration", expiration);
             String jsonStr = GSON.toJson(json) + "\n";
 
             HttpRequest request = HttpRequest.newBuilder()
@@ -67,7 +73,7 @@ public class PasteApi {
                 JsonObject response = GSON.fromJson(result.data(), JsonObject.class);
                 String id = response.get("id").getAsString();
                 URI uri = URI.create(response.get("link").getAsString());
-                return new Paste(id, uri);
+                return new Paste(id, uri, expiration);
             } catch (JsonSyntaxException | IllegalArgumentException e) {
                 throw new IOException("Invalid response", e);
             }
@@ -76,7 +82,7 @@ public class PasteApi {
             throw new IOException("Interrupted", e);
         }
     }
-    
+
     public void delete(String pasteId) throws IOException {
         try {
             HttpRequest request = HttpRequest.newBuilder()
@@ -94,7 +100,7 @@ public class PasteApi {
                     return HttpResponse.BodySubscribers.replacing(new Result(info.statusCode(), null));
                 }
             }).body();
-            
+
             if (result.data() == null) throw new IOException("HTTP status code " + result.code());
             try {
                 JsonObject response = GSON.fromJson(result.data(), JsonObject.class);
@@ -107,6 +113,6 @@ public class PasteApi {
             throw new IOException("Interrupted", e);
         }
     }
-    
-    public record Paste(String id, URI uri) {}
+
+    public record Paste(String id, URI uri, int expiration) {}
 }

--- a/src/main/java/org/moddingx/pastewrapper/PasteApi.java
+++ b/src/main/java/org/moddingx/pastewrapper/PasteApi.java
@@ -35,12 +35,12 @@ public class PasteApi {
     }
 
     public Paste createPaste(@Nullable String title, String content) throws IOException {
-        return this.createPaste(title, content, CreateRoute.DEFAULT_EXPIRATION);
+        return this.createPaste(title, content, CreateRoute.EXPIRATION_ONE_YEAR);
     }
 
     public Paste createPaste(@Nullable String title, String content, int expirationSeconds) throws IOException {
         try {
-            expirationSeconds = Math.min(expirationSeconds, CreateRoute.DEFAULT_EXPIRATION);
+            expirationSeconds = Math.min(expirationSeconds, CreateRoute.EXPIRATION_ONE_YEAR);
             JsonObject json = new JsonObject();
             if (title != null) json.addProperty("description", title);
             JsonArray sections = new JsonArray();
@@ -49,7 +49,7 @@ public class PasteApi {
             section.addProperty("contents", content);
             sections.add(section);
             json.add("sections", sections);
-            json.addProperty("expirationSeconds", expirationSeconds);
+            json.addProperty("expiration", expirationSeconds);
             String jsonStr = GSON.toJson(json) + "\n";
 
             HttpRequest request = HttpRequest.newBuilder()

--- a/src/main/java/org/moddingx/pastewrapper/PasteApi.java
+++ b/src/main/java/org/moddingx/pastewrapper/PasteApi.java
@@ -38,8 +38,9 @@ public class PasteApi {
         return this.createPaste(title, content, CreateRoute.DEFAULT_EXPIRATION);
     }
 
-    public Paste createPaste(@Nullable String title, String content, int expiration) throws IOException {
+    public Paste createPaste(@Nullable String title, String content, int expirationSeconds) throws IOException {
         try {
+            expirationSeconds = Math.min(expirationSeconds, CreateRoute.DEFAULT_EXPIRATION);
             JsonObject json = new JsonObject();
             if (title != null) json.addProperty("description", title);
             JsonArray sections = new JsonArray();
@@ -48,7 +49,7 @@ public class PasteApi {
             section.addProperty("contents", content);
             sections.add(section);
             json.add("sections", sections);
-            json.addProperty("expiration", expiration);
+            json.addProperty("expirationSeconds", expirationSeconds);
             String jsonStr = GSON.toJson(json) + "\n";
 
             HttpRequest request = HttpRequest.newBuilder()
@@ -73,7 +74,7 @@ public class PasteApi {
                 JsonObject response = GSON.fromJson(result.data(), JsonObject.class);
                 String id = response.get("id").getAsString();
                 URI uri = URI.create(response.get("link").getAsString());
-                return new Paste(id, uri, expiration);
+                return new Paste(id, uri, expirationSeconds);
             } catch (JsonSyntaxException | IllegalArgumentException e) {
                 throw new IOException("Invalid response", e);
             }
@@ -114,5 +115,5 @@ public class PasteApi {
         }
     }
 
-    public record Paste(String id, URI uri, int expiration) {}
+    public record Paste(String id, URI uri, int expirationSeconds) {}
 }

--- a/src/main/java/org/moddingx/pastewrapper/route/CreateRoute.java
+++ b/src/main/java/org/moddingx/pastewrapper/route/CreateRoute.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 public class CreateRoute extends JsonRoute {
 
-    public static final int DEFAULT_EXPIRATION = 60 * 60 * 24 * 365;
+    public static final int EXPIRATION_ONE_YEAR = 60 * 60 * 24 * 365;
 
     public CreateRoute(Service spark, PasteApi api, EditKeyManager mgr) {
         super(spark, api, mgr);
@@ -22,14 +22,14 @@ public class CreateRoute extends JsonRoute {
     @Override
     protected JsonElement apply(Request request, Response response) throws IOException {
         String title = request.queryParams("title");
-        int expirationSeconds = request.queryParams("expirationSeconds") == null ? DEFAULT_EXPIRATION : Integer.parseInt(request.queryParams("expirationSeconds"));
+        int expirationSeconds = request.queryParams("expiration") == null ? EXPIRATION_ONE_YEAR : Integer.parseInt(request.queryParams("expiration"));
         String content = request.body();
         if (content == null || content.isEmpty()) throw this.spark.halt(400, "No Content");
         PasteApi.Paste paste = this.api.createPaste(title, content, expirationSeconds);
         JsonObject json = new JsonObject();
         json.addProperty("url", paste.uri().toString());
         json.addProperty("edit", this.mgr.getEditToken(paste.id()));
-        json.addProperty("expirationSeconds", paste.expirationSeconds());
+        json.addProperty("expiration", paste.expirationSeconds());
         return json;
     }
 }

--- a/src/main/java/org/moddingx/pastewrapper/route/CreateRoute.java
+++ b/src/main/java/org/moddingx/pastewrapper/route/CreateRoute.java
@@ -12,7 +12,9 @@ import spark.Service;
 import java.io.IOException;
 
 public class CreateRoute extends JsonRoute {
-    
+
+    public static final int DEFAULT_EXPIRATION = 60 * 60 * 24 * 7 * 4;
+
     public CreateRoute(Service spark, PasteApi api, EditKeyManager mgr) {
         super(spark, api, mgr);
     }
@@ -20,12 +22,14 @@ public class CreateRoute extends JsonRoute {
     @Override
     protected JsonElement apply(Request request, Response response) throws IOException {
         String title = request.queryParams("title");
+        int expiration = request.queryParams("expiration") == null ? DEFAULT_EXPIRATION : Integer.parseInt(request.queryParams("expiration"));
         String content = request.body();
         if (content == null || content.isEmpty()) throw this.spark.halt(400, "No Content");
-        PasteApi.Paste paste = this.api.createPaste(title, content);
+        PasteApi.Paste paste = this.api.createPaste(title, content, expiration);
         JsonObject json = new JsonObject();
         json.addProperty("url", paste.uri().toString());
         json.addProperty("edit", this.mgr.getEditToken(paste.id()));
+        json.addProperty("expiration", paste.expiration());
         return json;
     }
 }

--- a/src/main/java/org/moddingx/pastewrapper/route/CreateRoute.java
+++ b/src/main/java/org/moddingx/pastewrapper/route/CreateRoute.java
@@ -22,7 +22,12 @@ public class CreateRoute extends JsonRoute {
     @Override
     protected JsonElement apply(Request request, Response response) throws IOException {
         String title = request.queryParams("title");
-        int expirationSeconds = request.queryParams("expiration") == null ? EXPIRATION_ONE_YEAR : Integer.parseInt(request.queryParams("expiration"));
+        int expirationSeconds;
+        try {
+            expirationSeconds = request.queryParams("expiration") == null ? EXPIRATION_ONE_YEAR : Integer.parseInt(request.queryParams("expiration"));
+        } catch (NumberFormatException e) {
+            throw this.spark.halt(400, "Invalid expiration seconds: " + request.queryParams("expiration"));
+        }
         String content = request.body();
         if (content == null || content.isEmpty()) throw this.spark.halt(400, "No Content");
         PasteApi.Paste paste = this.api.createPaste(title, content, expirationSeconds);

--- a/src/main/java/org/moddingx/pastewrapper/route/CreateRoute.java
+++ b/src/main/java/org/moddingx/pastewrapper/route/CreateRoute.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 public class CreateRoute extends JsonRoute {
 
-    public static final int DEFAULT_EXPIRATION = 60 * 60 * 24 * 7 * 4;
+    public static final int DEFAULT_EXPIRATION = 60 * 60 * 24 * 365;
 
     public CreateRoute(Service spark, PasteApi api, EditKeyManager mgr) {
         super(spark, api, mgr);
@@ -22,14 +22,14 @@ public class CreateRoute extends JsonRoute {
     @Override
     protected JsonElement apply(Request request, Response response) throws IOException {
         String title = request.queryParams("title");
-        int expiration = request.queryParams("expiration") == null ? DEFAULT_EXPIRATION : Integer.parseInt(request.queryParams("expiration"));
+        int expirationSeconds = request.queryParams("expirationSeconds") == null ? DEFAULT_EXPIRATION : Integer.parseInt(request.queryParams("expirationSeconds"));
         String content = request.body();
         if (content == null || content.isEmpty()) throw this.spark.halt(400, "No Content");
-        PasteApi.Paste paste = this.api.createPaste(title, content, expiration);
+        PasteApi.Paste paste = this.api.createPaste(title, content, expirationSeconds);
         JsonObject json = new JsonObject();
         json.addProperty("url", paste.uri().toString());
         json.addProperty("edit", this.mgr.getEditToken(paste.id()));
-        json.addProperty("expiration", paste.expiration());
+        json.addProperty("expirationSeconds", paste.expirationSeconds());
         return json;
     }
 }


### PR DESCRIPTION
The `expiration` field is not documented. As you can see at this screenshot, it does work:
![image](https://github.com/ModdingX/PasteWrapper/assets/26039509/0b0655df-ecea-45b7-b71b-d8504418ff11)

On the web interface, you can only create logs with a expiration time up to 1 year. The screenshot was made with value of max int.